### PR TITLE
Fix build by adapting react-icon types

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,11 +8,9 @@ import Footer from './components/Footer/Footer';
 const GlobalStyle = createGlobalStyle`
    body {
      margin: 0;
-    padding-top: 80px;
-    padding-bottom: 60px;
-    padding-top: 80px;    /* space for fixed header */
-    padding-bottom: 60px; /* space for footer */
-    background: ${({ theme }) => theme.colors.background}; /* make the page black */
+     padding-top: 80px;    /* space for fixed header */
+     padding-bottom: 60px; /* space for footer */
+     background: ${({ theme }) => theme.colors.background};
    }
  `;
 

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import * as S from './Footer.styles';
-import { FaFacebookF, FaInstagram } from 'react-icons/fa';
+import { FaFacebookF as FaFacebookFIcon, FaInstagram as FaInstagramIcon } from 'react-icons/fa';
+import type { IconBaseProps } from 'react-icons';
+
+const FacebookIcon = FaFacebookFIcon as unknown as React.FC<IconBaseProps>;
+const InstagramIcon = FaInstagramIcon as unknown as React.FC<IconBaseProps>;
 
 const Footer: React.FC = () => (
   <S.Wrapper>
@@ -12,14 +16,14 @@ const Footer: React.FC = () => (
 
     <S.SocialLinks>
       <S.IconLink href="https://www.facebook.com/YourPage" target="_blank" aria-label="Facebook">
-        <FaFacebookF />
+        <FacebookIcon />
       </S.IconLink>
       <S.IconLink
         href="https://www.instagram.com/YourProfile"
         target="_blank"
         aria-label="Instagram"
       >
-        <FaInstagram />
+        <InstagramIcon />
       </S.IconLink>
     </S.SocialLinks>
 

--- a/src/components/Newsletter/Newsletter.styles.ts
+++ b/src/components/Newsletter/Newsletter.styles.ts
@@ -1,4 +1,4 @@
-// src/components/Hero/Hero.styles.ts
+// src/components/Newsletter/Newsletter.styles.ts
 import styled from 'styled-components';
 
 export const Wrapper = styled.section`

--- a/src/components/Newsletter/Newsletter.tsx
+++ b/src/components/Newsletter/Newsletter.tsx
@@ -1,4 +1,4 @@
-// src/components/Hero/Hero.tsx
+// src/components/Newsletter/Newsletter.tsx
 import React from 'react';
 import * as S from './Newsletter.styles';
 


### PR DESCRIPTION
## Summary
- clean up duplicate global styles
- fix incorrect comments in Newsletter components
- cast react-icon components to work with React 19's JSX types

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68406d6c1b908320b791b8031d8a43da