### PR TITLE
Add pages for About Us and Newsletter

### DIFF
--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -17,11 +17,11 @@ import * as S from './Hero.styles';
 const images = ['/images/hero1.jpg', '/images/hero2.jpg', '/images/hero3.jpg'];
 
 const categories = [
-  'Haute Couture',
-  'Fashion & Fragrance',
-  'Fine Jewelry & Makeup',
-  'Watches & Skincare',
-  'Inside Chanel',
+  { name: 'Haute Couture', link: null },
+  { name: 'About Us', link: '/about-us' },
+  { name: 'Fine Jewelry & Makeup', link: null },
+  { name: 'Newsletter', link: '/newsletter' },
+  { name: 'Inside Chanel', link: null },
 ];
 
 const Hero: React.FC = () => {
@@ -74,7 +74,7 @@ const Hero: React.FC = () => {
       {/* Category labels underneath (always shown) */}
       <S.LabelsRow>
         {categories.map((cat) => (
-          <S.LabelItem key={cat}>{cat}</S.LabelItem>
+          <S.LabelItem key={cat.name}>{cat.name}</S.LabelItem>
         ))}
       </S.LabelsRow>
     </S.Wrapper>

--- a/src/pages/AboutUs.tsx
+++ b/src/pages/AboutUs.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const AboutUs: React.FC = () => (
+  <div>
+    <h1>About Us</h1>
+    <p>More information coming soon.</p>
+  </div>
+);
+
+export default AboutUs;

--- a/src/pages/NewsletterPage.tsx
+++ b/src/pages/NewsletterPage.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const NewsletterPage: React.FC = () => (
+  <div>
+    <h1>Newsletter</h1>
+    <p>Subscribe to our newsletter. More updates coming soon.</p>
+  </div>
+);
+
+export default NewsletterPage;

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -5,5 +5,6 @@ import { theme } from './theme';
 // tell styled-components what our theme shape is
 declare module 'styled-components' {
   type ThemeType = typeof theme;
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
   export interface DefaultTheme extends ThemeType {}
 }


### PR DESCRIPTION
## Summary
- create simple About Us and Newsletter pages

## Testing
- `npm run lint`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840780a947483208b1c1c3bff538fce