### PR TITLE
Fix navigation links using HashRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ npm run build
 ## Deploy on Railway
 - Connect this GitHub repo in Railway
 - Railway auto-runs `npm install && npm run build && npm run serve`
+
+## Routing
+This project uses `HashRouter` from React Router so navigation works even when
+hosted on static file servers. Links like **About Us** and **Newsletter** use
+hash-based URLs (e.g. `#/about-us`), ensuring the pages load correctly without
+additional server configuration.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import Home from './pages/Home';
 import AboutUs from './pages/AboutUs';
 import NewsletterPage from './pages/NewsletterPage';
 import Footer from './components/Footer/Footer';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { HashRouter as Router, Routes, Route } from 'react-router-dom';
 
 const GlobalStyle = createGlobalStyle`
    body {

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -81,7 +81,7 @@ const Hero: React.FC = () => {
             </S.LabelLink>
           ) : (
             <S.LabelItem key={cat.name}>{cat.name}</S.LabelItem>
-          )
+          ),
         )}
       </S.LabelsRow>
     </S.Wrapper>


### PR DESCRIPTION
## Summary
- switch to `HashRouter` so navigation works on static hosts
- document hash-based routing in the README
- fix lint error in `Hero.tsx`

## Testing
- `npm run lint`
- `CI=true npm test -- -b` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840857c3a1883209e7c28a0466de243