### PR TITLE
Update typography with Google fonts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
       content="Website created using create-react-app"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Inter:wght@400;600&display=swap" rel="stylesheet" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,14 @@ const GlobalStyle = createGlobalStyle`
      padding-top: 0px;    /* space for fixed header */
      padding-bottom: 0px; /* space for footer */
      background: ${({ theme }) => theme.colors.background};
+     color: ${({ theme }) => theme.colors.text};
+     font-family: ${({ theme }) => theme.fonts.sans};
+   }
+
+   h1,
+   h2,
+   h3 {
+     font-family: ${({ theme }) => theme.fonts.serif};
    }
  `;
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -6,6 +6,6 @@ export const theme = {
   },
   fonts: {
     serif: "'Playfair Display', serif",
-    sans: "'Helvetica Neue', sans-serif",
+    sans: "'Inter', sans-serif",
   },
 };


### PR DESCRIPTION
## Summary
- load Playfair Display and Inter from Google Fonts
- apply global font families for body and headings
- update theme fonts to use Inter

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6880e80e8c1083209cc4b6298e80e5ae