### PR TITLE
Remove beige background from product images

### DIFF
--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -10,11 +10,7 @@ interface ProductCardProps {
 
 const ProductCard: React.FC<ProductCardProps> = ({ image, name, price }) => (
   <S.Card>
-    <S.Image
-      src={image}
-      alt={name}
-      style={{ background: '#fef5e6', borderRadius: '8px', padding: '1rem' }}
-    />
+    <S.Image src={image} alt={name} style={{ borderRadius: '8px', padding: '1rem' }} />
     <S.Name>{name}</S.Name>
     {price && <S.Price>{price}</S.Price>}
   </S.Card>


### PR DESCRIPTION
## Summary
- remove the beige background style from `ProductCard` images

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_688a8cf103d083208d15927e7300a9bf