### PR TITLE
Remove console usage to allow production build

### DIFF
--- a/src/components/Checkout/CheckoutForm.tsx
+++ b/src/components/Checkout/CheckoutForm.tsx
@@ -225,7 +225,6 @@ const CheckoutForm: React.FC<CheckoutFormProps> = ({ total }) => {
       }
     } catch (err) {
       setError('An unexpected error occurred');
-      console.error('Payment error:', err);
     } finally {
       setLoading(false);
     }

--- a/src/services/paymentService.ts
+++ b/src/services/paymentService.ts
@@ -57,7 +57,6 @@ export class PaymentService {
       const data = await response.json();
       return data;
     } catch (error) {
-      console.error('Error creating payment intent:', error);
       // For demo purposes, return a mock payment intent
       return {
         id: 'pi_mock_' + Date.now(),
@@ -89,10 +88,9 @@ export class PaymentService {
         throw new Error('Failed to confirm payment');
       }
 
-      const data = await response.json();
+      await response.json();
       return { success: true };
     } catch (error) {
-      console.error('Error confirming payment:', error);
       // For demo purposes, simulate a successful payment
       return { success: true };
     }
@@ -110,7 +108,6 @@ export class PaymentService {
       const data = await response.json();
       return { status: data.status };
     } catch (error) {
-      console.error('Error getting payment status:', error);
       // For demo purposes, return a successful status
       return { status: 'succeeded' };
     }


### PR DESCRIPTION
## Summary
- remove console statements from checkout form and payment service
- drop unused variable in payment service

## Testing
- `npm run lint`
- `CI=true npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689512644b4483208d4c94a876be15c0