### PR TITLE
feat: add product group image to home

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -87,6 +87,11 @@ const Home: React.FC = () => {
         </Paragraph>
         <Paragraph>Your next scene starts now.</Paragraph>
       </Section>
+      <img
+        src={`${process.env.PUBLIC_URL}/images/Product_Group.jpg`}
+        alt="Product group"
+        style={{ width: isMobile ? '60px' : '80px', margin: '2rem auto', display: 'block' }}
+      />
       <FeaturedProducts />
       <HeroTextSection title="Ready to Glow?" subtitle="Sign up for exclusive deals and updates.">
         <span


### PR DESCRIPTION
## Summary
- show product group image above featured products on the home page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68952406343c8320b97d6badec408048