### PR TITLE
feat: show product group as hero image

### DIFF
--- a/src/components/ImageHero/ImageHero.styles.ts
+++ b/src/components/ImageHero/ImageHero.styles.ts
@@ -1,0 +1,43 @@
+// src/components/ImageHero/ImageHero.styles.ts
+import styled from 'styled-components';
+
+export const Wrapper = styled.section`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0rem 0;
+
+  @media (max-width: 600px) {
+    padding: 0.5rem 0;
+  }
+`;
+
+export const Container = styled.div`
+  position: relative;
+  width: 75%;
+  max-width: 1200px;
+  height: 0;
+  padding-top: calc((9 / 16) * 100%); /* 16:9 aspect-ratio */
+  overflow: hidden;
+  border-radius: 0.1rem;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+
+  @media (max-width: 600px) {
+    width: 98vw;
+    border-radius: 0.7rem;
+    box-shadow: 0 0 4px rgba(0, 0, 0, 0.18);
+  }
+`;
+
+export const Image = styled.img`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+
+  @media (max-width: 600px) {
+    border-radius: 0.7rem;
+  }
+`;

--- a/src/components/ImageHero/ImageHero.tsx
+++ b/src/components/ImageHero/ImageHero.tsx
@@ -1,0 +1,18 @@
+// src/components/ImageHero/ImageHero.tsx
+import React from 'react';
+import * as S from './ImageHero.styles';
+
+interface ImageHeroProps {
+  src: string;
+  alt?: string;
+}
+
+const ImageHero: React.FC<ImageHeroProps> = ({ src, alt }) => (
+  <S.Wrapper>
+    <S.Container>
+      <S.Image src={src} alt={alt} />
+    </S.Container>
+  </S.Wrapper>
+);
+
+export default ImageHero;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import HeroTextSection from '../components/Hero/HeroTextSection';
 import FeaturedProducts from '../components/FeaturedProducts/FeaturedProducts';
 import Newsletter from '../components/Newsletter/Newsletter';
 import { useIsMobile } from '../hooks/useIsMobile';
+import ImageHero from '../components/ImageHero/ImageHero';
 
 const Section = styled.section`
   width: 75%;
@@ -87,11 +88,7 @@ const Home: React.FC = () => {
         </Paragraph>
         <Paragraph>Your next scene starts now.</Paragraph>
       </Section>
-      <img
-        src={`${process.env.PUBLIC_URL}/images/Product_Group.jpg`}
-        alt="Product group"
-        style={{ width: isMobile ? '60px' : '80px', margin: '2rem auto', display: 'block' }}
-      />
+      <ImageHero src={`${process.env.PUBLIC_URL}/images/Product_Group.jpg`} alt="Product group" />
       <FeaturedProducts />
       <HeroTextSection title="Ready to Glow?" subtitle="Sign up for exclusive deals and updates.">
         <span


### PR DESCRIPTION
## Summary
- create ImageHero component for static hero imagery
- use ImageHero to display Product_Group as large hero on homepage

## Testing
- `npm run lint`
- `npm test -- --watchAll=false` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68952bf5d1e883209630679df726c406