### PR TITLE
Refine mobile layout with compact fonts and grids

### DIFF
--- a/src/components/FeaturedProducts/FeaturedProducts.styles.ts
+++ b/src/components/FeaturedProducts/FeaturedProducts.styles.ts
@@ -32,7 +32,7 @@ export const Grid = styled.div`
   margin-bottom: 2rem;
 
   @media (max-width: 600px) {
-    grid-template-columns: repeat(2, minmax(120px, 1fr));
+    grid-template-columns: repeat(3, 1fr);
     gap: 0.4rem;
     margin-bottom: 0.7rem;
   }

--- a/src/components/Header/Header.styles.ts
+++ b/src/components/Header/Header.styles.ts
@@ -17,8 +17,8 @@ export const Wrapper = styled.header`
   z-index: 1000;
 
   @media (max-width: 600px) {
-    height: 56px;
-    font-size: 1.1rem;
+    height: 48px;
+    font-size: 1rem;
     padding: 0 0.2rem;
   }
 `;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -14,14 +14,14 @@ const Header: React.FC = () => {
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
-          padding: '0 2rem',
+          padding: '0 1rem',
         }}
       >
         <Link
           to="/"
           style={{
             fontWeight: 700,
-            fontSize: '1.5rem',
+            fontSize: 'clamp(1.2rem, 6vw, 1.5rem)',
             color: '#fff',
             textDecoration: 'none',
             fontFamily: 'Georgia, serif',
@@ -36,7 +36,7 @@ const Header: React.FC = () => {
               color: '#fff',
               textDecoration: 'none',
               fontWeight: 500,
-              fontSize: '1.2rem',
+              fontSize: 'clamp(0.9rem, 4.5vw, 1.2rem)',
               display: 'flex',
               alignItems: 'center',
             }}

--- a/src/components/Hero/Hero.styles.ts
+++ b/src/components/Hero/Hero.styles.ts
@@ -12,7 +12,7 @@ interface SlideProps {
  * 2) SlidesContainer: flex container that holds up to three slides.
  * 3) SlideCard: individual slide (prev/center/next). Rounded corners, background-image, etc.
  *    - On desktop: prev and next are smaller + translucent; center is larger + fully opaque.
- *    - On mobile (<576px): ONLY the center slide gets flex: 0 0 70%; the two side cards are effectively hidden (overflow: hidden).
+ *    - On mobile (<576px): all three slides are shown with equal spacing and slightly reduced scale.
  * 4) Arrow: left/right arrow, absolutely positioned at mid-height.
  *    - Hidden on mobile (<576px).
  * 5) LabelsRow: row of category labels beneath the slides.
@@ -48,8 +48,9 @@ export const SlidesContainer = styled.div`
   height: 420px;
 
   @media (max-width: 576px) {
-    width: 98vw;
+    width: 100%;
     height: 220px;
+    gap: 0.5rem;
   }
 `;
 
@@ -78,12 +79,12 @@ export const SlideCard = styled.div<SlideProps>`
     isActive ? '0 4px 32px rgba(0,0,0,0.25)' : '0 2px 8px rgba(0,0,0,0.10)'};
 
   @media (max-width: 576px) {
-    flex: 0 0 90%;
+    flex: 0 0 32%;
     opacity: 1 !important;
-    transform: scale(1) translateX(0);
+    transform: scale(${({ isActive }) => (isActive ? 1 : 0.9)}) translateX(0);
     background-position: center;
     margin: 0;
-    border-radius: 0.7rem;
+    border-radius: 0.5rem;
   }
 `;
 

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -1,6 +1,5 @@
 // src/components/Hero/Hero.tsx
 import React, { useState, useEffect } from 'react';
-import { useIsMobile } from '../../hooks/useIsMobile';
 import * as S from './Hero.styles';
 import { Link } from 'react-router-dom';
 
@@ -26,7 +25,6 @@ const categories = [
 const Hero: React.FC = () => {
   const [current, setCurrent] = useState(0);
   const len = images.length;
-  const isMobile = useIsMobile(576); // true if viewport <576px
 
   // Next/Prev handlers
   const next = () => setCurrent((c) => (c + 1) % len);
@@ -60,17 +58,9 @@ const Hero: React.FC = () => {
       </S.Arrow>
 
       <S.SlidesContainer>
-        {isMobile ? (
-          // 🚀 MOBILE LAYOUT: only show the center slide
-          <S.SlideCard image={images[current]} isActive={true} position="center" />
-        ) : (
-          // 🖥 DESKTOP LAYOUT: show prev, current, next
-          <>
-            <S.SlideCard image={images[prevIdx]} isActive={false} position="prev" />
-            <S.SlideCard image={images[current]} isActive={true} position="center" />
-            <S.SlideCard image={images[nextIdx]} isActive={false} position="next" />
-          </>
-        )}
+        <S.SlideCard image={images[prevIdx]} isActive={false} position="prev" />
+        <S.SlideCard image={images[current]} isActive={true} position="center" />
+        <S.SlideCard image={images[nextIdx]} isActive={false} position="next" />
       </S.SlidesContainer>
 
       {/* Right arrow (hidden on mobile) */}

--- a/src/components/ProductCard/ProductCard.styles.ts
+++ b/src/components/ProductCard/ProductCard.styles.ts
@@ -65,7 +65,7 @@ export const Name = styled.div`
   margin-top: 0.75rem;
 
   @media (max-width: 600px) {
-    font-size: 1rem;
+    font-size: 0.9rem;
     margin-top: 0.5rem;
   }
 `;
@@ -78,7 +78,7 @@ export const Price = styled.div`
   margin-bottom: 1rem;
 
   @media (max-width: 600px) {
-    font-size: 0.95rem;
+    font-size: 0.85rem;
     margin-bottom: 0.5rem;
   }
 `;

--- a/src/index.css
+++ b/src/index.css
@@ -14,3 +14,12 @@ body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
+
+@media (max-width: 600px) {
+  html {
+    font-size: 14px;
+  }
+  body {
+    padding: 0 4px;
+  }
+}

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -238,8 +238,8 @@ const Grid = styled.div`
   gap: 2rem;
   width: 100%;
   @media (max-width: 600px) {
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    gap: 1rem;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.5rem;
   }
 `;
 


### PR DESCRIPTION
## Summary
- reduce default font size and add page padding on small screens
- shrink header and hero carousel for better mobile spacing
- show three product cards per row with smaller card text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68952f8e49908320ba32ada473658208