### PR TITLE
Refactor home page with mobile-first dark layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,6 @@ import AboutUs from './pages/AboutUs';
 import NewsletterPage from './pages/NewsletterPage';
 import Footer from './components/Footer/Footer';
 import { HashRouter as Router, Routes, Route } from 'react-router-dom';
-// import styled from 'styled-components';
 import Products from './pages/Products';
 import Cart from './pages/Cart';
 import Checkout from './pages/Checkout';
@@ -15,38 +14,28 @@ import ContactUs from './pages/ContactUs';
 import { CartProvider } from './context/CartContext';
 
 const GlobalStyle = createGlobalStyle`
-   body {
-     margin: 0;
-     padding-top: 0px;    /* space for fixed header */
-     padding-bottom: 0px; /* space for footer */
-     background: ${({ theme }) => theme.colors.background};
-     color: ${({ theme }) => theme.colors.text};
-     font-family: ${({ theme }) => theme.fonts.sans};
-   }
+  body {
+    margin: 0;
+    background: ${({ theme }) => theme.colors.background};
+    color: ${({ theme }) => theme.colors.text};
+    font-family: ${({ theme }) => theme.fonts.sans};
+    font-size: 14px;
+    line-height: 1.6;
+    letter-spacing: 0.1px;
+  }
 
-   h1,
-   h2,
-   body {
-     margin: 0;
-     padding-top: 0px;    /* space for fixed header */
-     padding-bottom: 0px; /* space for footer */
-     color: ${({ theme }) => theme.colors.text};
-     font-family: ${({ theme }) => theme.fonts.serif};
-   }
+  h1,
+  h2,
+  h3 {
+    margin: 0 0 8px;
+    font-family: ${({ theme }) => theme.fonts.serif};
+    font-weight: 700;
+    line-height: 1.25;
+  }
 
-   h1,
-   h2,
-   h3 {
-     font-family: ${({ theme }) => theme.fonts.serif};
-   }
-      rgba(255, 255, 255, 0.05) 4%,
-      rgba(255, 255, 255, 0) 15%,
-      rgba(255, 255, 255, 0) 85%,
-      rgba(255, 255, 255, 0.05) 96%,
-      rgba(255, 255, 255, 0.1) 98%,
-      rgba(255, 255, 255, 0.15) 100%
-    ),
-    #000;
+  h1 { font-size: 22px; }
+  h2 { font-size: 18px; }
+  h3 { font-size: 16px; }
 `;
 
 const App: React.FC = () => (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,112 +1,213 @@
 import React from 'react';
 import styled from 'styled-components';
-import Hero from '../components/Hero/Hero';
-import VideoHero from '../components/VideoHero/VideoHero';
-import HeroTextSection from '../components/Hero/HeroTextSection';
-import FeaturedProducts from '../components/FeaturedProducts/FeaturedProducts';
-import Newsletter from '../components/Newsletter/Newsletter';
-import { useIsMobile } from '../hooks/useIsMobile';
-import ImageHero from '../components/ImageHero/ImageHero';
+import { products } from '../components/FeaturedProducts/FeaturedProducts';
 
-const Section = styled.section`
-  width: 75%;
-  max-width: 1200px;
-  margin: 2.5rem auto 0 auto;
-  padding: 3rem 2rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  border-radius: 0.1rem;
-  background: #181818;
-  color: #fff;
-  box-shadow: 0 2px 16px rgba(0, 0, 0, 0.12);
-
-  @media (max-width: 768px) {
-    width: 98vw;
-    padding: 2rem 0.5rem;
-    margin: 1.5rem auto 0 auto;
-    border-radius: 0.5rem;
-  }
-`;
-
-const Heading = styled.h2`
-  font-family: ${({ theme }) => theme.fonts.serif};
-  font-size: 2.5rem;
-  margin-bottom: 1.2rem;
-
-  @media (max-width: 768px) {
-    font-size: 1.6rem;
-  }
-`;
-
-const Paragraph = styled.p`
-  max-width: 700px;
-  font-size: 1.1rem;
-  line-height: 1.7;
+const Page = styled.main`
+  max-width: 420px;
   margin: 0 auto;
-  color: #eee;
-  @media (max-width: 768px) {
-    font-size: 1rem;
-  }
+  padding: 0 16px;
+  background: #0f0f0f;
+  color: #eaeaea;
 `;
 
-const Home: React.FC = () => {
-  const isMobile = useIsMobile(768);
-  return (
-    <>
-      <Hero />
-      <img
-        src={`${process.env.PUBLIC_URL}/logo_wht.png`}
-        alt="KK Beauty Lab logo"
-        style={{ width: isMobile ? '60px' : '80px', margin: '2rem auto', display: 'block' }}
-      />
-      <Section className="bio">
-        <Heading>Discover Your New Favorites</Heading>
-        <Paragraph>Every face tells a story. Every story deserves to be seen.</Paragraph>
-      </Section>
-      <VideoHero />
-      <Section className="why-shop">
-        <Heading>Why shop with us:</Heading>
-        <Paragraph>
-          In a world of filters and facades, true beauty breaks through the noise. Your skin is your
-          canvas. Your confidence, the masterpiece.
-        </Paragraph>
-        <Paragraph>
-          This is your moment to step into the spotlight—unapologetically, authentically,
-          brilliantly you.
-        </Paragraph>
-        <Paragraph>
-          Our curated collection of luxury skincare transforms your daily ritual into something
-          extraordinary. From breakthrough serums that rewrite your skin&apos;s story to bold
-          statements that command attention, each product is designed for those who refuse to fade
-          into the background.
-        </Paragraph>
-        <Paragraph>
-          Because when you embrace your authentic self, you don&apos;t just change how you look—you
-          change how the world sees possibility.
-        </Paragraph>
-        <Paragraph>Your next scene starts now.</Paragraph>
-      </Section>
-      <ImageHero src={`${process.env.PUBLIC_URL}/images/Product_Group.jpg`} alt="Product group" />
-      <FeaturedProducts />
-      <HeroTextSection title="Ready to Glow?" subtitle="Sign up for exclusive deals and updates.">
-        <span
-          style={{
-            maxWidth: '700px',
-            fontSize: '1.1rem',
-            lineHeight: '1.7',
-            margin: '0 auto',
-            color: '#eee',
-          }}
-        >
-          Join our newsletter and be the first to know about new products, special promotions, and
-          beauty tips. Your journey to radiant skin and confidence starts here—don’t miss out!
-        </span>
-      </HeroTextSection>
-      <Newsletter />
-    </>
-  );
-};
+const BrandRow = styled.div`
+  text-align: center;
+  font-size: 18px;
+  font-weight: 700;
+  padding: 12px 0;
+`;
+
+const MediaStrip = styled.div`
+  display: flex;
+  overflow-x: auto;
+  gap: 8px;
+  padding: 8px;
+  scroll-snap-type: x mandatory;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar { display: none; }
+`;
+
+const MediaItem = styled.img`
+  flex: 0 0 auto;
+  width: 96px;
+  height: 96px;
+  border-radius: 12px;
+  object-fit: cover;
+  scroll-snap-align: center;
+`;
+
+const Card = styled.section`
+  background: #161616;
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: 16px;
+  box-shadow: 0 6px 18px rgba(0,0,0,.4);
+  padding: 16px;
+  margin: 20px 0;
+`;
+
+const VideoContainer = styled.div`
+  aspect-ratio: 16/9;
+  width: 100%;
+  border-radius: 16px;
+  overflow: hidden;
+  margin-top: 12px;
+`;
+
+const Banner = styled.img`
+  width: 100%;
+  border-radius: 16px;
+  object-fit: cover;
+  aspect-ratio: 16/9;
+  margin: 12px 0;
+`;
+
+const ProductsStrip = styled.div`
+  display: flex;
+  overflow-x: auto;
+  gap: 8px;
+  padding: 8px 0;
+  scroll-snap-type: x mandatory;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar { display: none; }
+`;
+
+const ProductCard = styled.div`
+  flex: 0 0 auto;
+  width: 112px;
+  border-radius: 14px;
+  background: #121212;
+  border: 1px solid rgba(255,255,255,.06);
+  padding: 10px;
+  text-align: center;
+  scroll-snap-align: center;
+`;
+
+const ProductImage = styled.img`
+  width: 100%;
+  aspect-ratio: 1/1;
+  border-radius: 10px;
+  object-fit: cover;
+  margin-bottom: 8px;
+`;
+
+const ProductName = styled.div`
+  font-size: 12px;
+  line-height: 1.3;
+  min-height: 32px;
+`;
+
+const ProductPrice = styled.div`
+  font-size: 12px;
+  opacity: .85;
+`;
+
+const ViewAll = styled.a`
+  display: block;
+  height: 44px;
+  line-height: 44px;
+  padding: 0 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,.12);
+  background: #1d1d1d;
+  text-align: center;
+  text-decoration: none;
+  color: #eaeaea;
+  margin: 0 auto;
+`;
+
+const NewsletterForm = styled.form`
+  display: flex;
+  width: 100%;
+  margin-top: 16px;
+`;
+
+const NewsletterInput = styled.input`
+  flex: 1;
+  height: 44px;
+  border-radius: 999px;
+  padding: 0 14px;
+  background: #111;
+  border: 1px solid rgba(255,255,255,.12);
+  color: #eaeaea;
+`;
+
+const NewsletterButton = styled.button`
+  height: 44px;
+  margin-left: 8px;
+  border-radius: 999px;
+  padding: 0 16px;
+  background: #eaeaea;
+  color: #0f0f0f;
+  font-weight: 600;
+`;
+
+const FooterLinks = styled.footer`
+  text-align: center;
+  font-size: 12px;
+  opacity: .85;
+  padding: 16px 0;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+`;
+
+const Home: React.FC = () => (
+  <Page>
+    <BrandRow>KK Beauty Lab</BrandRow>
+    <MediaStrip>
+      {products.slice(0,4).map(p => (
+        <MediaItem key={p.id} src={p.image} alt={p.name} />
+      ))}
+    </MediaStrip>
+    <Card style={{ padding: '16px 16px 0 16px' }}>
+      <h1>Discover Your New Favorites</h1>
+      <h2 style={{ fontSize: '16px', fontWeight: 700 }}>Every face tells a story. Every story deserves to be seen.</h2>
+    </Card>
+    <VideoContainer>
+      <video controls poster="/images/Product_Group.jpg" style={{ width: '100%', height: '100%' }}>
+        <source src="/videos/hero.mp4" type="video/mp4" />
+      </video>
+    </VideoContainer>
+    <Card>
+      <h2>Why shop with us:</h2>
+      <p>In a world of filters and facades, true beauty breaks through the noise. Your skin is your canvas. Your confidence, the masterpiece.</p>
+      <p style={{ marginTop: 8 }}>This is your moment to step into the spotlight—unapologetically, authentically, brilliantly you.</p>
+      <p style={{ marginTop: 8 }}>Our curated collection of luxury skincare transforms your daily ritual into something extraordinary. From breakthrough serums that rewrite your skin's story to bold statements that command attention, each product is designed for those who refuse to fade into the background.</p>
+      <p style={{ marginTop: 8 }}>Because when you embrace your authentic self, you don't just change how you look—you change how the world sees possibility.</p>
+      <p style={{ marginTop: 8 }}>Your next scene starts now.</p>
+    </Card>
+    <Banner src="/images/Product_Group.jpg" alt="Product group" />
+    <Card style={{ textAlign: 'center' }}>
+      <h2>Featured Products</h2>
+      <ProductsStrip>
+        {products.map(p => (
+          <ProductCard key={p.id}>
+            <ProductImage src={p.image} alt={p.name} />
+            <ProductName>{p.name}</ProductName>
+            <ProductPrice>{p.price}</ProductPrice>
+          </ProductCard>
+        ))}
+      </ProductsStrip>
+      <ViewAll href="/products">View All</ViewAll>
+    </Card>
+    <Card style={{ textAlign: 'center' }}>
+      <h2 style={{ fontSize: 18 }}>Ready to Glow?</h2>
+      <p>Join our newsletter and be the first to know about new products, special promotions, and beauty tips.</p>
+      <NewsletterForm>
+        <NewsletterInput type="email" placeholder="Email address" />
+        <NewsletterButton type="submit">Subscribe</NewsletterButton>
+      </NewsletterForm>
+    </Card>
+    <FooterLinks>
+      <span>Contact</span>
+      <span>|</span>
+      <span>Privacy</span>
+      <span>|</span>
+      <span>Terms</span>
+    </FooterLinks>
+  </Page>
+);
 
 export default Home;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,7 +1,7 @@
 export const theme = {
   colors: {
-    background: '#000000',
-    text: '#FFFFFF',
+    background: '#0f0f0f',
+    text: '#eaeaea',
     accent: '#BBBBBB',
   },
   fonts: {


### PR DESCRIPTION
## Summary
- Rework global theme and typography to use dark background, soft text color, and mobile-friendly type scale
- Rebuild Home page with centered 420px container, scrollable media strip, unified card sections, and horizontal featured products list
- Streamline newsletter form and footer links for compact mobile presentation

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6895367fee9c83209305ca43155f5847