### PR TITLE
feat: add new home hero carousel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,7 @@ const App: React.FC = () => (
             <Route path="/shop" element={<Products />} />
             <Route path="/collections" element={<Products />} />
             <Route path="/about-us" element={<AboutUs />} />
+            <Route path="/about" element={<AboutUs />} />
             <Route path="/products" element={<Products />} />
             <Route path="/newsletter" element={<NewsletterPage />} />
             <Route path="/cart" element={<Cart />} />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { products } from '../components/FeaturedProducts/FeaturedProducts';
-import HeroCarousel from '../components/HeroCarousel/HeroCarousel';
 import '../styles/home.css';
 
 const Page = styled.main`
@@ -166,9 +165,42 @@ const FooterLinks = styled.footer`
   gap: 10px;
 `;
 
+const hero1 = '/images/hero1.jpg';
+const hero2 = '/images/hero3.jpg';
+const hero3 = '/images/Product_Group.jpg';
+
 const Home: React.FC = () => (
   <Page>
-    <HeroCarousel />
+    <section className="hero">
+      <div className="hero__container">
+        <div className="carousel" aria-label="Featured products">
+          <div className="carousel__track">
+            <img src={hero1} alt="KK Beauty Lab product 1" className="slide slide--left" />
+            <img src={hero2} alt="KK Beauty Lab product 2" className="slide slide--center" />
+            <img src={hero3} alt="KK Beauty Lab product 3" className="slide slide--right" />
+          </div>
+        </div>
+
+        <nav className="hero__nav">
+          <Link to="/about">ABOUT US</Link>
+          <Link to="/products">OUR PRODUCTS</Link>
+          <Link to="/newsletter">NEWSLETTER</Link>
+          <Link to="/contact">CONTACT US</Link>
+        </nav>
+
+        <h1 className="hero__logo">KK</h1>
+
+        <div className="hero__cta">
+          <Link to="/shop" className="btn">
+            Shop Now
+          </Link>
+          <Link to="/collections" className="btn btn--ghost">
+            Explore Collections
+          </Link>
+        </div>
+      </div>
+    </section>
+
     <BrandRow>KK Beauty Lab</BrandRow>
     <MediaStrip>
       {products.slice(0, 4).map((p) => (
@@ -198,13 +230,13 @@ const Home: React.FC = () => (
       </p>
       <p style={{ marginTop: 8 }}>
         Our curated collection of luxury skincare transforms your daily ritual into something
-        extraordinary. From breakthrough serums that rewrite your skin's story to bold statements
-        that command attention, each product is designed for those who refuse to fade into the
-        background.
+        extraordinary. From breakthrough serums that rewrite your skin&apos;s story to bold
+        statements that command attention, each product is designed for those who refuse to fade
+        into the background.
       </p>
       <p style={{ marginTop: 8 }}>
-        Because when you embrace your authentic self, you don't just change how you look—you change
-        how the world sees possibility.
+        Because when you embrace your authentic self, you don&apos;t just change how you look—you
+        change how the world sees possibility.
       </p>
       <p style={{ marginTop: 8 }}>Your next scene starts now.</p>
     </Card>

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -1,12 +1,115 @@
-.hero-carousel img {
-  width: 100%;
-  height: 60vh;
-  object-fit: cover;
-  border-radius: 16px;
+:root {
+  --heroMax: 75vw;
+  --radius: 14px;
+}
+.hero {
+  background: #000;
+  color: #ddd;
+  padding: 56px 0 40px;
+}
+.hero__container {
+  margin: 0 auto;
+  max-width: var(--heroMax);
 }
 
-@media (max-width: 768px) {
-  .hero-carousel img {
-    height: auto;
+/* mobile base */
+.carousel {
+  overflow: hidden;
+  padding: 0 16px;
+}
+.carousel__track {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 16px;
+}
+.slide {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  border-radius: var(--radius);
+  opacity: 0.9;
+}
+.slide--center {
+  height: 260px;
+  opacity: 1;
+}
+
+/* nav under carousel */
+.hero__nav {
+  display: flex;
+  gap: 28px;
+  justify-content: center;
+  align-items: center;
+  margin: 28px 0 18px;
+  letter-spacing: 0.12em;
+  font-size: 12px;
+}
+.hero__nav a {
+  color: #d7d5d5;
+  text-decoration: none;
+}
+.hero__nav a:hover {
+  text-decoration: underline;
+}
+
+/* centered logo */
+.hero__logo {
+  text-align: center;
+  font-weight: 600;
+  font-size: 32px;
+  margin: 18px 0 0;
+  color: #e9e7e7;
+}
+
+/* optional CTA buttons (hidden on your screenshot; leave for desktop/tablet) */
+.hero__cta {
+  margin-top: 16px;
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+.btn {
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid #e9e7e7;
+  color: #111;
+  background: #e9e7e7;
+}
+.btn--ghost {
+  background: transparent;
+  color: #e9e7e7;
+}
+
+/* desktop ≥ 992px */
+@media (min-width: 992px) {
+  .hero__container {
+    max-width: min(1200px, 75%);
+  }
+  .carousel {
+    padding: 0;
+  }
+  .slide {
+    height: 360px;
+  }
+  .slide--center {
+    height: 440px;
+  }
+  .hero__nav {
+    gap: 36px;
+    font-size: 13px;
+  }
+  .hero__logo {
+    font-size: 40px;
+  }
+}
+
+/* tiny phones */
+@media (max-width: 360px) {
+  .slide {
+    height: 160px;
+  }
+  .slide--center {
+    height: 210px;
   }
 }


### PR DESCRIPTION
## Summary
- redesign home page hero with centered carousel, nav row, logo, and call-to-action buttons
- restore original home content (video, brand rows, featured products) beneath the new hero
- add `/about` route so hero navigation links work

## Testing
- `npm test -- --watchAll=false` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a6de637908320aeebbc41e2ac243d