### PR TITLE
Autoplay home page video

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -210,7 +210,7 @@ const Home: React.FC = () => (
       </h2>
     </Card>
     <VideoContainer>
-      <video controls poster="/images/Product_Group.jpg" style={{ width: '100%', height: '100%' }}>
+      <video autoPlay loop playsInline style={{ width: '100%', height: '100%' }}>
         <source src="/videos/hero.mp4" type="video/mp4" />
       </video>
     </VideoContainer>


### PR DESCRIPTION
## Summary
- Autoplay the home page video without controls or poster and now allow sound by removing the `muted` attribute.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_689cfe3599fc8320b23bcb021f6fa52a