### PR TITLE
Make home carousel full width

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,8 +5,8 @@ import '../styles/home.css';
 import styled from 'styled-components';
 
 const Page = styled.main`
-  width: 75vw;
-  max-width: 1200px;
+  width: 100%;
+  max-width: 100%;
   margin: 0 auto;
   padding: 0;
   background: #0f0f0f;

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -1,5 +1,5 @@
 :root {
-  --heroMax: 75vw;
+  --heroMax: 100%;
   --radius: 14px;
 }
 .hero {
@@ -84,7 +84,7 @@
 /* desktop ≥ 992px */
 @media (min-width: 992px) {
   .hero__container {
-    max-width: min(1200px, 75%);
+    max-width: 100%;
   }
   .carousel {
     padding: 0;


### PR DESCRIPTION
## Summary
- Expand home carousel container to full viewport width
- Allow home page layout to span entire width

## Testing
- `npm test -- --watchAll=false` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d098e82e08320b97788e856afaea8