### PR TITLE
style: enlarge and center home page text

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -11,6 +11,8 @@ const Page = styled.main`
   padding: 0;
   background: #0f0f0f;
   color: #eaeaea;
+  text-align: center;
+  font-size: 18px;
   @media (max-width: 768px) {
     width: 100%;
     padding: 0 12px;
@@ -104,13 +106,13 @@ const ProductImage = styled.img`
 `;
 
 const ProductName = styled.div`
-  font-size: 12px;
+  font-size: 18px;
   line-height: 1.3;
   min-height: 32px;
 `;
 
 const ProductPrice = styled.div`
-  font-size: 12px;
+  font-size: 18px;
   opacity: 0.85;
 `;
 
@@ -143,6 +145,8 @@ const NewsletterInput = styled.input`
   background: #111;
   border: 1px solid rgba(255, 255, 255, 0.12);
   color: #eaeaea;
+  font-size: 18px;
+  text-align: center;
 `;
 
 const NewsletterButton = styled.button`
@@ -157,7 +161,7 @@ const NewsletterButton = styled.button`
 
 const FooterLinks = styled.footer`
   text-align: center;
-  font-size: 12px;
+  font-size: 18px;
   opacity: 0.85;
   padding: 16px 0;
   display: flex;

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -6,6 +6,8 @@
   background: transparent;
   color: #ddd;
   padding: 56px 0 40px;
+  text-align: center;
+  font-size: 18px;
 }
 .hero__container {
   margin: 0 auto;
@@ -43,11 +45,13 @@
   align-items: center;
   margin: 28px 0 18px;
   letter-spacing: 0.12em;
-  font-size: 12px;
+  font-size: 18px;
+  text-align: center;
 }
 .hero__nav a {
   color: #d7d5d5;
   text-decoration: none;
+  text-align: center;
 }
 .hero__nav a:hover {
   text-decoration: underline;
@@ -68,6 +72,8 @@
   display: flex;
   gap: 12px;
   justify-content: center;
+  font-size: 18px;
+  text-align: center;
 }
 .btn {
   padding: 10px 18px;
@@ -97,7 +103,7 @@
   }
   .hero__nav {
     gap: 36px;
-    font-size: 13px;
+    font-size: 18px;
   }
   .hero__logo {
     font-size: 40px;


### PR DESCRIPTION
## Summary
- center-align and enlarge typography across the home page
- update hero nav, product cards, and footer to use consistent 18px text

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d10925d708320927e4279d6bc42ec