### PR TITLE
Replace direct console logging with logger

### DIFF
--- a/src/components/Checkout/CheckoutForm.tsx
+++ b/src/components/Checkout/CheckoutForm.tsx
@@ -3,6 +3,7 @@ import { CardElement, useStripe, useElements } from '@stripe/react-stripe-js';
 import styled from 'styled-components';
 import { useCart } from '../../context/CartContext';
 import paymentService from '../../services/paymentService';
+import logger from '../../utils/logger';
 
 const FormContainer = styled.div`
   background: rgba(24, 24, 24, 0.98);
@@ -331,15 +332,15 @@ const CheckoutForm: React.FC<CheckoutFormProps> = ({ total }) => {
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
-    console.log('🚀 Form submitted - starting payment process');
+    logger.debug('🚀 Form submitted - starting payment process');
     e.preventDefault();
 
     if (!stripe || !elements) {
-      console.log('❌ Stripe or elements not loaded');
+      logger.debug('❌ Stripe or elements not loaded');
       return;
     }
 
-    console.log('✅ Stripe and elements loaded, proceeding...');
+    logger.debug('✅ Stripe and elements loaded, proceeding...');
     setLoading(true);
     setError(null);
 
@@ -352,7 +353,7 @@ const CheckoutForm: React.FC<CheckoutFormProps> = ({ total }) => {
 
     try {
       // Step 1: Create payment intent on backend
-      console.log('Creating payment intent with:', {
+      logger.debug('Creating payment intent with:', {
         amount: parseFloat(cartTotal),
         items: items.length,
         customer: formData.name,
@@ -372,13 +373,13 @@ const CheckoutForm: React.FC<CheckoutFormProps> = ({ total }) => {
         },
       );
 
-      console.log('Payment intent created successfully, client_secret received');
+      logger.debug('Payment intent created successfully, client_secret received');
 
       // Step 2: Confirm payment with Stripe
-      console.log('🔄 Confirming payment with Stripe...');
-      console.log('🔑 Using client_secret:', client_secret);
-      console.log('💳 Card element:', cardElement);
-      console.log('📋 Billing details:', {
+      logger.debug('🔄 Confirming payment with Stripe...');
+      logger.debug('🔑 Using client_secret:', client_secret);
+      logger.debug('💳 Card element:', cardElement);
+      logger.debug('📋 Billing details:', {
         name: formData.name,
         email: formData.email,
         address: formData.address,
@@ -403,24 +404,24 @@ const CheckoutForm: React.FC<CheckoutFormProps> = ({ total }) => {
         },
       });
 
-      console.log('🎯 Stripe confirmCardPayment completed!');
-      console.log('📨 Full Stripe response:', { error, paymentIntent });
-      console.log('✅ Payment intent object:', paymentIntent);
-      console.log('📊 Payment intent status:', paymentIntent?.status);
-      console.log('❌ Error object:', error);
-      console.log('🔍 Error type:', typeof error);
-      console.log('🔍 PaymentIntent type:', typeof paymentIntent);
+      logger.debug('🎯 Stripe confirmCardPayment completed!');
+      logger.debug('📨 Full Stripe response:', { error, paymentIntent });
+      logger.debug('✅ Payment intent object:', paymentIntent);
+      logger.debug('📊 Payment intent status:', paymentIntent?.status);
+      logger.debug('❌ Error object:', error);
+      logger.debug('🔍 Error type:', typeof error);
+      logger.debug('🔍 PaymentIntent type:', typeof paymentIntent);
 
       if (error) {
-        console.error('Payment failed:', error);
+        logger.error('Payment failed:', error);
         showErrorPopup('Payment Failed', error.message || 'Payment failed. Please try again.');
-        console.log('Error popup should show now');
+        logger.debug('Error popup should show now');
       } else if (paymentIntent && paymentIntent.status === 'succeeded') {
-        console.log('✅ Payment succeeded! Processing success flow...');
-        console.log('Payment intent details:', paymentIntent);
+        logger.debug('✅ Payment succeeded! Processing success flow...');
+        logger.debug('Payment intent details:', paymentIntent);
 
         // Send confirmation to backend and wait for response
-        console.log('📡 Sending confirmation to backend...');
+        logger.debug('📡 Sending confirmation to backend...');
         try {
           const backendResponse = await paymentService.paymentSuccess(
             paymentIntent.id,
@@ -435,12 +436,12 @@ const CheckoutForm: React.FC<CheckoutFormProps> = ({ total }) => {
             },
             total.toString(),
           );
-          console.log('✅ Backend confirmation successful:', backendResponse);
+          logger.debug('✅ Backend confirmation successful:', backendResponse);
 
           // Only show success popup AFTER backend confirms
           showSuccessPopup(backendResponse, total.toString());
         } catch (confirmError) {
-          console.error('❌ Backend confirmation failed:', confirmError);
+          logger.error('❌ Backend confirmation failed:', confirmError);
           // Show error popup if backend fails
           showErrorPopup(
             'Order Confirmation Failed',
@@ -449,10 +450,10 @@ const CheckoutForm: React.FC<CheckoutFormProps> = ({ total }) => {
         }
       } else {
         // Handle cases where payment intent exists but status is not 'succeeded'
-        console.log('⚠️ Unexpected payment state:');
-        console.log('Payment Intent:', paymentIntent);
-        console.log('Status:', paymentIntent?.status);
-        console.log('Error:', error);
+        logger.debug('⚠️ Unexpected payment state:');
+        logger.debug('Payment Intent:', paymentIntent);
+        logger.debug('Status:', paymentIntent?.status);
+        logger.debug('Error:', error);
 
         // Show error popup for unexpected states
         showErrorPopup(
@@ -461,10 +462,10 @@ const CheckoutForm: React.FC<CheckoutFormProps> = ({ total }) => {
         );
       }
     } catch (err) {
-      console.error('Error:', err);
+      logger.error('Error:', err);
       showErrorPopup('Unexpected Error', 'An unexpected error occurred. Please try again.');
     } finally {
-      console.log('🏁 Payment process completed, setting loading to false');
+      logger.debug('🏁 Payment process completed, setting loading to false');
       setLoading(false);
     }
   };
@@ -474,7 +475,7 @@ const CheckoutForm: React.FC<CheckoutFormProps> = ({ total }) => {
     backendResponse: { success: boolean; orderId: string; message: string },
     amount: string,
   ) => {
-    console.log('🎉 Showing success popup with backend data:', backendResponse);
+    logger.debug('🎉 Showing success popup with backend data:', backendResponse);
     const popupDataToSet = {
       type: 'success' as const,
       title: 'Payment Successful!',
@@ -484,17 +485,17 @@ const CheckoutForm: React.FC<CheckoutFormProps> = ({ total }) => {
       orderId: backendResponse.orderId,
       amount: amount,
     };
-    console.log('📋 Setting popup data:', popupDataToSet);
+    logger.debug('📋 Setting popup data:', popupDataToSet);
     setPopupData(popupDataToSet);
-    console.log('🔄 Setting showPopup to true...');
+    logger.debug('🔄 Setting showPopup to true...');
     setShowPopup(true);
     setSuccess(true);
-    console.log('✅ Popup state should now be visible');
+    logger.debug('✅ Popup state should now be visible');
   };
 
   // Helper function to show error popup
   const showErrorPopup = (title: string, message: string) => {
-    console.log('❌ Showing error popup:', { title, message });
+    logger.debug('❌ Showing error popup:', { title, message });
     setPopupData({
       type: 'error',
       title,

--- a/src/components/Checkout/StripeProvider.tsx
+++ b/src/components/Checkout/StripeProvider.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
+import logger from '../../utils/logger';
 // Load Stripe with publishable key from environment variables
 const publishableKey = process.env.REACT_APP_STRIPE_PUBLISHABLE_KEY;
 
 // Debug logging for environment variables
 
 if (!publishableKey) {
-  console.error('REACT_APP_STRIPE_PUBLISHABLE_KEY is not defined in environment variables');
+  logger.error('REACT_APP_STRIPE_PUBLISHABLE_KEY is not defined in environment variables');
   throw new Error('Stripe publishable key is required but not found in environment variables');
 }
 

--- a/src/services/paymentService.ts
+++ b/src/services/paymentService.ts
@@ -1,6 +1,8 @@
-﻿// This is a mock payment service
+// This is a mock payment service
 // In a real application, this would communicate with your backend server
 // which would then communicate with Stripe's API
+
+import logger from '../utils/logger';
 
 export interface PaymentIntent {
   id: string;
@@ -44,8 +46,8 @@ export class PaymentService {
   private constructor() {
     // In production, this would be your backend API URL
     const apiUrl = process.env.REACT_APP_BACKEND_API_URL || 'http://localhost:3001/api';
-    console.log('API URL from env:', process.env.REACT_APP_BACKEND_API_URL);
-    console.log('Final API URL:', apiUrl);
+    logger.debug('API URL from env:', process.env.REACT_APP_BACKEND_API_URL);
+    logger.debug('Final API URL:', apiUrl);
     this.baseUrl = apiUrl;
   }
 
@@ -63,10 +65,10 @@ export class PaymentService {
     items?: CartItem[],
     customer?: CustomerInfo,
   ): Promise<{ client_secret: string }> {
-    console.log('🔄 PaymentService: Creating payment intent...');
-    console.log('📍 URL:', `${this.baseUrl}/create-payment-intent`);
-    console.log('💰 Amount:', amount, '→', Math.round(amount * 100), 'cents');
-    console.log('📦 Payload:', { amount: Math.round(amount * 100), currency, items, customer });
+    logger.debug('🔄 PaymentService: Creating payment intent...');
+    logger.debug('📍 URL:', `${this.baseUrl}/create-payment-intent`);
+    logger.debug('💰 Amount:', amount, '→', Math.round(amount * 100), 'cents');
+    logger.debug('📦 Payload:', { amount: Math.round(amount * 100), currency, items, customer });
 
     const response = await fetch(`${this.baseUrl}/create-payment-intent`, {
       method: 'POST',
@@ -81,18 +83,18 @@ export class PaymentService {
       }),
     });
 
-    console.log('📨 Response status:', response.status, response.statusText);
-    console.log('📨 Response ok:', response.ok);
+    logger.debug('📨 Response status:', response.status, response.statusText);
+    logger.debug('📨 Response ok:', response.ok);
 
     if (!response.ok) {
       const errorText = await response.text();
-      console.error('❌ Backend error:', errorText);
+      logger.error('❌ Backend error:', errorText);
       throw new Error(`Failed to create payment intent: ${response.status} ${errorText}`);
     }
 
     const data = await response.json();
-    console.log('✅ Payment intent response:', data);
-    console.log('🔑 Client secret received:', data.client_secret ? 'YES' : 'NO');
+    logger.debug('✅ Payment intent response:', data);
+    logger.debug('🔑 Client secret received:', data.client_secret ? 'YES' : 'NO');
     return data;
   }
 
@@ -103,9 +105,9 @@ export class PaymentService {
     customer: CustomerInfo,
     total: string,
   ): Promise<{ success: boolean; orderId: string; message: string }> {
-    console.log('🔄 PaymentService: Sending request to backend...');
-    console.log('URL:', `${this.baseUrl}/payment-success`);
-    console.log('Payload:', { paymentIntentId, items, customer, total });
+    logger.debug('🔄 PaymentService: Sending request to backend...');
+    logger.debug('URL:', `${this.baseUrl}/payment-success`);
+    logger.debug('Payload:', { paymentIntentId, items, customer, total });
 
     const response = await fetch(`${this.baseUrl}/payment-success`, {
       method: 'POST',
@@ -120,17 +122,17 @@ export class PaymentService {
       }),
     });
 
-    console.log('📨 Backend response status:', response.status);
-    console.log('📨 Backend response ok:', response.ok);
+    logger.debug('📨 Backend response status:', response.status);
+    logger.debug('📨 Backend response ok:', response.ok);
 
     if (!response.ok) {
       const errorText = await response.text();
-      console.error('❌ Backend error response:', errorText);
+      logger.error('❌ Backend error response:', errorText);
       throw new Error(`Failed to confirm payment with backend: ${response.status} ${errorText}`);
     }
 
     const data = await response.json();
-    console.log('✅ Backend response data:', data);
+    logger.debug('✅ Backend response data:', data);
     return data;
   }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,22 @@
+/* eslint-disable no-console */
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+type ConsoleMethod = 'log' | 'info' | 'warn' | 'error';
+
+const isDebugEnabled = process.env.NODE_ENV !== 'production';
+
+const log = (level: LogLevel, ...args: unknown[]) => {
+  const method: ConsoleMethod = level === 'debug' ? 'log' : level;
+  if (isDebugEnabled || method === 'error' || method === 'warn') {
+    console[method](...args);
+  }
+};
+
+export const logger = {
+  debug: (...args: unknown[]) => log('debug', ...args),
+  info: (...args: unknown[]) => log('info', ...args),
+  warn: (...args: unknown[]) => log('warn', ...args),
+  error: (...args: unknown[]) => log('error', ...args),
+};
+
+export default logger;


### PR DESCRIPTION
## Summary
- add a reusable logger utility to centralize browser logging behavior
- replace direct console usage in the checkout components and payment service with the logger so builds no longer fail in CI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68edcc5345e48320bb2c10808870c07e